### PR TITLE
Connections are now directly responsible for sending packages

### DIFF
--- a/Beacon/Net/Connection.cs
+++ b/Beacon/Net/Connection.cs
@@ -121,8 +121,7 @@ public sealed class Connection : IDisposable
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error processing server bound packet");
-            }
+                _logger.LogError(ex, "Error processing client bound packet");
         }
         
     }

--- a/Beacon/Net/Packets/Login/ServerBound/Hello.cs
+++ b/Beacon/Net/Packets/Login/ServerBound/Hello.cs
@@ -26,11 +26,11 @@ public class Hello : IServerBoundPacket, IPipeReadable<Hello>, IDisposable
     
     public void Handle(Server server, Connection connection)
     {
-        server.EnqueuePacket(new LoginFinished
+        connection.EnqueuePacket(new LoginFinished
         {
             Username = Name,
             Uuid = PlayerUuid
-        }, connection);
+        });
     }
 
     public static Hello Deserialize(ref SequenceReader<byte> reader)

--- a/Beacon/Net/Packets/Status/ServerBound/StatusRequest.cs
+++ b/Beacon/Net/Packets/Status/ServerBound/StatusRequest.cs
@@ -18,6 +18,6 @@ public sealed class StatusRequest : IServerBoundPacket
     public void Handle(Server server, Connection connection)
     {
         var res = new StatusResponse(connection);
-        server.EnqueuePacket(res, connection);
+        connection.EnqueuePacket(res);
     }
 }


### PR DESCRIPTION

This pull request refactors the packet handling system in the `Beacon` project to improve modularity and maintainability. Key changes include moving client-bound packet processing logic from the `Server` class to the `Connection` class, introducing a dedicated channel for client-bound packets within `Connection`, and updating logging and packet enqueuing mechanisms.

Closes #9 since each connection now needs a packet.